### PR TITLE
support for setting tournament time control on init and/or on play

### DIFF
--- a/example_tournament.py
+++ b/example_tournament.py
@@ -1,7 +1,7 @@
 import multiprocessing
 
 import tilewe 
-import tilewe.engine 
+import tilewe.engine
 
 tournament = tilewe.engine.Tournament([
     tilewe.engine.RandomEngine("Random 1"), 
@@ -10,4 +10,4 @@ tournament = tilewe.engine.Tournament([
     tilewe.engine.RandomEngine("Random 4")
 ])
 
-tournament.play(1000, n_threads=multiprocessing.cpu_count())
+tournament.play(1000, n_threads=multiprocessing.cpu_count(), move_seconds=15)

--- a/tilewe/engine.py
+++ b/tilewe/engine.py
@@ -36,14 +36,15 @@ class Tournament:
 
     def __init__(self, engines: list[Engine], move_seconds: int=60): 
         self.engines = list(engines)
-        self.move_seconds = move_seconds
+        self.default_move_seconds = move_seconds
+        self.move_seconds = self.default_move_seconds
 
     def play(self, n_games: int, n_threads: int=1, move_seconds: int=None):
         # initialize trackers and game controls
         games = 0
         wins = [0 for _ in range(len(self.engines))]
         totals = [0 for _ in range(len(self.engines))]
-        if move_seconds is not None: self.move_seconds = move_seconds
+        self.move_seconds = move_seconds if move_seconds is not None else self.default_move_seconds
 
         N = len(self.engines)
 
@@ -78,7 +79,6 @@ class Tournament:
 
         try: 
             engine_to_player = { value: key for key, value in enumerate(player_to_engine) }
-
             while not board.finished: 
                 engine = self.engines[player_to_engine[board.current_player]]
                 move = engine.search(board.copy_current_state(), self.move_seconds) 

--- a/tilewe/engine.py
+++ b/tilewe/engine.py
@@ -36,15 +36,15 @@ class Tournament:
 
     def __init__(self, engines: list[Engine], move_seconds: int=60): 
         self.engines = list(engines)
-        self.default_move_seconds = move_seconds
-        self.move_seconds = self.default_move_seconds
+        self._seconds = move_seconds
+        self.move_seconds = self._seconds
 
     def play(self, n_games: int, n_threads: int=1, move_seconds: int=None):
         # initialize trackers and game controls
         games = 0
         wins = [0 for _ in range(len(self.engines))]
         totals = [0 for _ in range(len(self.engines))]
-        self.move_seconds = move_seconds if move_seconds is not None else self.default_move_seconds
+        self.move_seconds = move_seconds if move_seconds is not None else self._seconds
 
         N = len(self.engines)
 

--- a/tilewe/engine.py
+++ b/tilewe/engine.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import traceback
 import random
 import signal
 import time 
@@ -33,22 +34,27 @@ class RandomEngine(Engine):
 
 class Tournament: 
 
-    def __init__(self, engines: list[Engine]): 
-        self.engines = list(engines) 
+    def __init__(self, engines: list[Engine], move_seconds: int=60): 
+        self.engines = list(engines)
+        self.move_seconds = move_seconds
 
-    def play(self, n_games: int, n_threads: int=1): 
+    def play(self, n_games: int, n_threads: int=1, move_seconds: int=None):
+        # initialize trackers and game controls
         games = 0
         wins = [0 for _ in range(len(self.engines))]
         totals = [0 for _ in range(len(self.engines))]
+        if move_seconds is not None: self.move_seconds = move_seconds
 
         N = len(self.engines)
 
+        # prepare turn orders for the various games
         args = [] 
         for _ in range(n_games): 
             order = list(range(N))
             random.shuffle(order) 
             args.append(order) 
 
+        # play games with the given level of concurrency
         with multiprocessing.Pool(n_threads, initializer=signal.signal, initargs=(signal.SIGINT, signal.SIG_IGN)) as pool: 
             try:
                 for winners, scores, _ in pool.imap_unordered(self._play_game, args): 
@@ -75,7 +81,7 @@ class Tournament:
 
             while not board.finished: 
                 engine = self.engines[player_to_engine[board.current_player]]
-                move = engine.search(board.copy_current_state(), 60.0) 
+                move = engine.search(board.copy_current_state(), self.move_seconds) 
                 # TODO test legality 
                 board.push(move) 
 
@@ -87,4 +93,5 @@ class Tournament:
             return winners, scores, board
         
         except: 
+            traceback.print_exc()
             return [], [], board 


### PR DESCRIPTION
- You can optionally specify `move_seconds` on tournament init, otherwise it defaults to 60 (like before)
- You can optionally specify `move_seconds` on calling `play` which updates the time control, otherwise no change