### PR TITLE
fix mappings of player and engine for reporting tournament results

### DIFF
--- a/tilewe/engine.py
+++ b/tilewe/engine.py
@@ -82,7 +82,7 @@ class Tournament:
             # put scores back in original engine order 
             winners = [ player_to_engine[x] for x in board.winners ]
             board_scores = board.scores
-            scores = [ board_scores[player_to_engine[i]] for i in range(len(self.engines)) ]
+            scores = [ board_scores[engine_to_player[i]] for i in range(len(self.engines)) ]
 
             return winners, scores, board
         

--- a/tilewe/engine.py
+++ b/tilewe/engine.py
@@ -80,7 +80,7 @@ class Tournament:
                 board.push(move) 
 
             # put scores back in original engine order 
-            winners = [ engine_to_player[x] for x in board.winners ]
+            winners = [ player_to_engine[x] for x in board.winners ]
             board_scores = board.scores
             scores = [ board_scores[player_to_engine[i]] for i in range(len(self.engines)) ]
 


### PR DESCRIPTION
As you can see here, when I was Engine 0 and Player R it gave the win (and score) incorrectly to Engine 1 (i.e. position R).
```python
tournament = tilewe.engine.Tournament([
    MichaelEngine("Michael 1"), 
    tilewe.engine.RandomEngine("Random 2"), 
    tilewe.engine.RandomEngine("Random 3"), 
    tilewe.engine.RandomEngine("Random 4")
])
```
```
Michael is player red
B: 45 ( I3 I4 Z4 O4 T4 I5 T5 V5 X5 Z5 )
Y: 41 ( I4 Z4 F5 I5 U5 V5 W5 X5 Y5 Z5 )
R: 80 ( I4 I5 )
G: 56 ( I4 O4 I5 V5 W5 X5 Z5 )
Finished: True
Winner: R 
Game 1:         winners: [1]    scores: [41, 80, 45, 56]        total wins: [0, 1, 0, 0]        total scores: [41, 80, 45, 56]
```

After the fix you can see even when Engine 0 is player G, it correctly gives the win and score to Engine 0:
```
Michael is player green
Game 1:         winners: [0]    scores: [89, 48, 45, 56]        total wins: [1, 0, 0, 0]        total scores: [89, 48, 45, 56]
```