### PR TITLE
Add method to efficiently get number of legal moves for a player

### DIFF
--- a/tilewe/__init__.py
+++ b/tilewe/__init__.py
@@ -621,9 +621,21 @@ class Board:
         prps = player.corners.get(tile, 0) # type: _PrpSet
         return (prps & (1 << prp_id)) != 0
         
+    def n_legal_moves(self, unique: bool=False, for_player: Color=None): 
+        if not unique: 
+            raise Exception("Non-unique rotations not supported yet") 
+        
+        player = self._players[self.current_player if for_player is None else for_player]
+        total = 0 
+
+        for prps in player.corners.values(): 
+            total += prps.bit_count() 
+
+        return total 
+
     def generate_legal_moves(self, unique: bool=False, for_player: Color=None): 
         if not unique: 
-            raise Exception("non-unique rotations not supported yet") 
+            raise Exception("Non-unique rotations not supported yet") 
         
         moves = [] # type: list[Move] 
 

--- a/tilewe/engine.py
+++ b/tilewe/engine.py
@@ -82,7 +82,7 @@ class MaximizeMoveDifferenceEngine(Engine):
             board.push(m) 
             total = 0
             for color in range(board.n_players): 
-                n_moves = len(board.generate_legal_moves(unique=True, for_player=color))
+                n_moves = board.n_legal_moves(unique=True, for_player=color)
                 total += n_moves * (1 if color == player else -1)
             board.pop() 
             return total


### PR DESCRIPTION
Previously to get the number of legal moves a player has we would have to generate all legal moves and get the length of the list. This adds a method that only computes the number of moves, which is useful when we don't actually need the moves themselves. 