### PR TITLE
Non-unique rotation support and small fixes

### DIFF
--- a/test.py
+++ b/test.py
@@ -176,5 +176,11 @@ class TestTilewe(unittest.TestCase):
         for move in moves: 
             self.assertTrue(move.to_unique() in unique)
 
+    def test_n_legal_moves(self): 
+        board = tilewe.Board(4) 
+        
+        self.assertTrue(board.n_legal_moves(unique=True) == len(board.generate_legal_moves(unique=True)))
+        self.assertTrue(board.n_legal_moves(unique=False) == len(board.generate_legal_moves(unique=False)))
+
 if __name__ == '__main__': 
     unittest.main() 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,163 @@
+import unittest 
+
+import tilewe 
+
+class TestTilewe(unittest.TestCase): 
+    
+    def test_unique_legal_move(self): 
+        board = tilewe.Board(4) 
+
+        self.assertTrue(board.is_legal(tilewe.Move(
+            piece=tilewe.Z5, 
+            rotation=tilewe.NORTH, 
+            contact=tilewe.A03, 
+            to_square=tilewe.A20
+        )))
+
+        self.assertTrue(board.is_legal(tilewe.Move(
+            piece=tilewe.Z5, 
+            rotation=tilewe.EAST, 
+            contact=tilewe.A01, 
+            to_square=tilewe.A01
+        )))
+
+        self.assertTrue(board.is_legal(tilewe.Move(
+            piece=tilewe.T4, 
+            rotation=tilewe.NORTH, 
+            contact=tilewe.A02, 
+            to_square=tilewe.A20
+        )))
+
+        self.assertTrue(board.is_legal(tilewe.Move(
+            piece=tilewe.T4, 
+            rotation=tilewe.EAST, 
+            contact=tilewe.B03, 
+            to_square=tilewe.T20
+        )))
+
+    def test_nonunique_legal_move(self): 
+        board = tilewe.Board(4) 
+
+        self.assertTrue(board.is_legal(tilewe.Move(
+            piece=tilewe.Z5, 
+            rotation=tilewe.SOUTH, 
+            contact=tilewe.A03, 
+            to_square=tilewe.A20
+        )))
+
+        self.assertTrue(board.is_legal(tilewe.Move(
+            piece=tilewe.Z5, 
+            rotation=tilewe.WEST, 
+            contact=tilewe.A01, 
+            to_square=tilewe.A01
+        )))
+
+        self.assertTrue(board.is_legal(tilewe.Move(
+            piece=tilewe.T4, 
+            rotation=tilewe.NORTH_F, 
+            contact=tilewe.A02, 
+            to_square=tilewe.A20
+        )))
+
+        self.assertTrue(board.is_legal(tilewe.Move(
+            piece=tilewe.T4, 
+            rotation=tilewe.WEST_F, 
+            contact=tilewe.B03, 
+            to_square=tilewe.T20
+        )))
+
+        self.assertTrue(board.is_legal(tilewe.Move(
+            piece=tilewe.O4, 
+            rotation=tilewe.WEST_F, 
+            contact=tilewe.B01, 
+            to_square=tilewe.T01
+        )))
+
+    def test_unique_illegal_move(self): 
+        board = tilewe.Board(4) 
+
+        # contact is valid, but tiles would be placed off the board 
+        self.assertFalse(board.is_legal(tilewe.Move(
+            piece=tilewe.Z5, 
+            rotation=tilewe.NORTH, 
+            contact=tilewe.A03, 
+            to_square=tilewe.A01
+        )))
+
+        # contact is not valid 
+        self.assertFalse(board.is_legal(tilewe.Move(
+            piece=tilewe.Z5, 
+            rotation=tilewe.NORTH, 
+            contact=tilewe.A01, 
+            to_square=tilewe.A01
+        )))
+
+        # contact is invalid, and tiles would be placed off the board
+        self.assertFalse(board.is_legal(tilewe.Move(
+            piece=tilewe.T4, 
+            rotation=tilewe.SOUTH, 
+            contact=tilewe.C02, 
+            to_square=tilewe.A20
+        )))
+
+        self.assertFalse(board.is_legal(tilewe.Move(
+            piece=None, 
+            rotation=tilewe.EAST, 
+            contact=tilewe.B03, 
+            to_square=tilewe.T20
+        )))
+
+        self.assertFalse(board.is_legal(tilewe.Move(
+            piece=tilewe.T4, 
+            rotation=None, 
+            contact=tilewe.B03, 
+            to_square=tilewe.T20
+        )))
+
+        self.assertFalse(board.is_legal(tilewe.Move(
+            piece=tilewe.T4, 
+            rotation=tilewe.EAST, 
+            contact=None, 
+            to_square=tilewe.T20
+        )))
+
+        self.assertFalse(board.is_legal(tilewe.Move(
+            piece=tilewe.T4, 
+            rotation=tilewe.EAST, 
+            contact=tilewe.B03, 
+            to_square=None
+        )))
+
+    def test_nonunique_illegal_move(self): 
+        board = tilewe.Board(4) 
+
+        self.assertFalse(board.is_legal(tilewe.Move(
+            piece=tilewe.Z5, 
+            rotation=tilewe.SOUTH, 
+            contact=tilewe.A03, 
+            to_square=tilewe.A01
+        )))
+
+        self.assertFalse(board.is_legal(tilewe.Move(
+            piece=tilewe.O4, 
+            rotation=tilewe.WEST_F, 
+            contact=tilewe.B01, 
+            to_square=tilewe.T20
+        )))
+
+        self.assertFalse(board.is_legal(tilewe.Move(
+            piece=tilewe.T4, 
+            rotation=tilewe.NORTH_F, 
+            contact=tilewe.A02, 
+            to_square=tilewe.A19
+        )))
+
+        self.assertFalse(board.is_legal(tilewe.Move(
+            piece=tilewe.T4, 
+            rotation=tilewe.WEST_F, 
+            contact=tilewe.B02, 
+            to_square=tilewe.T20
+        )))
+
+if __name__ == '__main__': 
+    unittest.main() 

--- a/test.py
+++ b/test.py
@@ -159,5 +159,22 @@ class TestTilewe(unittest.TestCase):
             to_square=tilewe.T20
         )))
 
+    def test_nonunique_move_gen_legal(self): 
+        board = tilewe.Board(4) 
+
+        moves = board.generate_legal_moves(unique=False) 
+
+        for move in moves: 
+            self.assertTrue(board.is_legal(move))
+
+    def test_nonunique_move_gen_has_unique_move(self): 
+        board = tilewe.Board(4) 
+
+        unique = board.generate_legal_moves(unique=True) 
+        moves = board.generate_legal_moves(unique=False) 
+
+        for move in moves: 
+            self.assertTrue(move.to_unique() in unique)
+
 if __name__ == '__main__': 
     unittest.main() 

--- a/tilewe/__init__.py
+++ b/tilewe/__init__.py
@@ -682,15 +682,25 @@ class Board:
         # permutation must fit at the corner square
         return (prps & prp.as_set) != 0
 
-    def n_legal_moves(self, unique: bool=False, for_player: Color=None): 
-        if not unique: 
-            raise Exception("Non-unique rotations not supported yet") 
-        
+    def n_legal_moves(self, unique: bool=True, for_player: Color=None): 
         player = self._players[self.current_player if for_player is None else for_player]
         total = 0 
 
-        for prps in player.corners.values(): 
-            total += prps.bit_count() 
+        if unique: 
+            for prps in player.corners.values(): 
+                total += prps.bit_count() 
+        else: 
+            for prps in player.corners.values(): 
+                while prps != 0: 
+                    # get least significant bit
+                    prp_id = (prps & -prps).bit_length() - 1
+                    # remove it so the next LSB is another PRP
+                    prps ^= 1 << prp_id
+
+                    prp = _PIECE_ROTATION_POINTS[prp_id]
+
+                    # include all rotations that are equivalent to this PRP
+                    total += len(prp.piece.true_rot_for[prp.rotation.rotation]) 
 
         return total 
 

--- a/tilewe/__init__.py
+++ b/tilewe/__init__.py
@@ -72,6 +72,8 @@ COLORS = [
     BLUE, YELLOW, RED, GREEN
 ] = [Color(x) for x in range(4)]
 
+NO_COLOR = -1 # type: Color 
+
 COLOR_NAMES = [
     'blue', 'yellow', 'red', 'green'
 ]
@@ -623,7 +625,7 @@ class Board:
         return len(self._remaining_piece_set(player))
     
     def color_at(self, tile: Tile) -> Color: 
-        return Color(self._tiles[tile])
+        return Color(self._tiles[tile] - 1)
 
     def _is_legal(self, prp_id: int, tile: Tile, player: Color=None) -> bool: 
         if player is None: 


### PR DESCRIPTION
## Non-unique rotation support

Non-unique piece rotations are now supported in legality testing and move generation. Internally, each piece keeps track of which rotations are equivalent and uses that when generating moves and transforming a `Move` into its unique version. 

An example of duplicate rotations: 
```
W5n   | W5e   | W5ef
. . X | X . . | . . X 
. X X | X X . | . X X
X X . | . X X | X X .
```
Note that W5n and W5ef have equivalent rotations. Since contact coordinates are determined after the rotation is applied, everything else about a move (piece, contact, target tile) are the same and only the rotation state is changed. 

## Tile color query

Previously, the result of `Board.color_at()` would return a value offset from the true color by 1. This is due to how board color is internally stored where 0 is an empty tile, 1 is player 1, etc. whereas we expect player 1 to be 0, 2 to be 1, etc. This is fixed by subtracting 1 from the original method's output. 