### PR TITLE
implement hash func for moves for use in set operations

### DIFF
--- a/tilewe/__init__.py
+++ b/tilewe/__init__.py
@@ -523,7 +523,12 @@ class Move:
                TILE_NAMES[TILES.index(self.to_square)]
     
     def __hash__(self):
-        return hash(self.__str__())
+        return self.piece * 2659 + \
+               self.rotation * 5393 + \
+               self.contact[0] * 571 + \
+               self.contact[1] * 683 + \
+               self.to_square[0] * 1607 + \
+               self.to_square[1] * 1741
     
     def is_equal(self, value: 'Move') -> bool: 
         return \

--- a/tilewe/__init__.py
+++ b/tilewe/__init__.py
@@ -522,6 +522,9 @@ class Move:
                TILE_NAMES[TILES.index(self.contact)] + \
                TILE_NAMES[TILES.index(self.to_square)]
     
+    def __hash__(self):
+        return hash(self.__str__())
+    
     def is_equal(self, value: 'Move') -> bool: 
         return \
             self.piece == value.piece and \


### PR DESCRIPTION
This PR implements the `__hash__` function for `tilewe.Move` so it can be used in set operations like:
- `if move in moveSet`
- `moveList = list(set(moveList))`
- etc.

given `moveList: list[tilewe.Move]` and `moveSet: set[tilewe.Move]`.