### PR TITLE
implement new elo outcome logic using win status instead of scores

### DIFF
--- a/tilewe/elo.py
+++ b/tilewe/elo.py
@@ -83,13 +83,21 @@ def compute_elo_adjustment_n(elos: list[float], scores: list[int], K: int = 32):
     player_count = len(elos)
     mod_K = K / (player_count - 1)
     delta_elos = [ 0 for _ in range(player_count)]
+    winning_score = max(scores)
 
     for player1 in range(player_count):
         for player2 in range(player_count):
             if player1 == player2:
                 continue
 
-            outcome = 0 if scores[player1] < scores[player2] else 1 if scores[player1] > scores[player2] else 0.5
+            # any player can win/draw/lose to any other player by score
+            #outcome = 0 if scores[player1] < scores[player2] else 1 if scores[player1] > scores[player2] else 0.5
+
+            # any losers lose to winners and draw with other losers / any winners win over losers and draw with other winners
+            player1_win = scores[player1] == winning_score
+            player2_win = scores[player2] == winning_score
+            outcome = 0 if player2_win and not player1_win else 1 if player1_win and not player2_win else 0.5
+
             delta_elo = compute_elo_adjustment_2(elos[player1], elos[player2], outcome, mod_K)
             delta_elos[player1] += delta_elo
 


### PR DESCRIPTION
New: **any losers lose to winners and draw with other losers / any winners win over losers and draw with other winners**
```
Rank Name                       Elo  Games      Score  Avg Score   Wins  Win Rate
   0 MoveDiff                   174    128      10311      80.55     89    69.53%
   1 LargestPiece                24    128       9428      73.66     39    30.47%
   2 Random                     -97    128       7449      58.20      4     3.12%
   3 WallCrawler               -101    128       6077      47.48      0     0.00%
```
Old: **any player can win/draw/lose to any other player by score**
```
Rank Name                       Elo  Games      Score  Avg Score   Wins  Win Rate
   0 MoveDiff                   310    128      10265      80.20     86    67.19%
   1 LargestPiece               190    128       9643      75.34     43    33.59%
   2 Random                    -168    128       7393      57.76      3     2.34%
   3 WallCrawler               -333    128       6192      48.38      0     0.00%
```
New logic is more draw heavy since losers can't sometimes "win" against other losers, which results in somewhat more stable Elo rankings.