### PR TITLE
Improve performance, fix wall crawler tile weight table bug

### DIFF
--- a/tilewe/__init__.py
+++ b/tilewe/__init__.py
@@ -424,6 +424,16 @@ _PRP_WITH_PC_ID: dict[int, _PrpSet] = defaultdict(_PrpSet)
 for _pt in _PIECE_ROTATION_POINTS: 
     _PRP_WITH_PC_ID[_pt.piece_id] |= _pt.as_set
 
+def tile_to_coords(tile: Tile) -> tuple[int, int]: 
+    return tile 
+
+def coords_to_tile(coords: tuple[int, int]) -> Tile: 
+    return coords 
+
+def tile_to_index(tile: Tile) -> int: 
+    # y * width + x
+    return tile[0] * 20 + tile[1]
+
 def out_of_bounds(tile: Tile) -> bool: 
     if tile[0] < 0 or tile[0] >= 20: 
         return True 

--- a/tilewe/engine.py
+++ b/tilewe/engine.py
@@ -163,30 +163,30 @@ class TileWeightEngine(Engine):
         'turtle' seems fairly weak (better than random but weaker than others)
     """
 
-    WALL_CRAWL_WEIGHTS: list[float] = [
-        1, 1,   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,   1,  
-        1, 0.9, 0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9, 1,  
-        1, 0.9, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.6,  0.6,  0.6,  0.6,  0.6,  0.6,  0.6,  0.6 , 0.6,  0.6,  0.6,  0.6,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.5,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.5,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.5,  0.4,  0.3,  0.3,  0.3,  0.3,  0.3,  0.3,  0.3,  0.3,  0.4,  0.5,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.5,  0.4,  0.3,  0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.3,  0.4,  0.5,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.5,  0.4,  0.3,  0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.3,  0.4,  0.5,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.5,  0.4,  0.3,  0.25, 0.1,  0.1,  0.1,  0.1,  0.25, 0.3,  0.4,  0.5,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.5,  0.4,  0.3,  0.25, 0.1,  0,    0,    0.1,  0.25, 0.3,  0.4,  0.5,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.5,  0.4,  0.3,  0.25, 0.1,  0.1,  0.1,  0.1,  0.25, 0.3,  0.4,  0.5,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.5,  0.4,  0.3,  0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.3,  0.4,  0.5,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.5,  0.4,  0.3,  0.3,  0.3,  0.3,  0.3,  0.3,  0.3,  0.3,  0.4,  0.5,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.5,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.5,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.6,  0.6,  0.6,  0.6,  0.6,  0.6,  0.6,  0.6,  0.6,  0.6,  0.6,  0.6,  0.6,  0.6,  0.75, 0.9, 1,  
-        1, 0.9, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.9, 1,  
-        1, 0.9, 0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9,  0.9, 1,  
-        1, 1,   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,   1
+    WALL_CRAWL_WEIGHTS: list[int] = [
+        100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 
+        100, 90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  100, 
+        100, 90,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  90,  100, 
+        100, 90,  75,  60,  60,  60,  60,  60,  60,  60,  60,  60,  60,  60,  60,  60,  60,  75,  90,  100, 
+        100, 90,  75,  60,  50,  50,  50,  50,  50,  50,  50,  50,  50,  50,  50,  50,  60,  75,  90,  100, 
+        100, 90,  75,  60,  50,  40,  40,  40,  40,  40,  40,  40,  40,  40,  40,  50,  60,  75,  90,  100, 
+        100, 90,  75,  60,  50,  40,  30,  30,  30,  30,  30,  30,  30,  30,  40,  50,  60,  75,  90,  100, 
+        100, 90,  75,  60,  50,  40,  30,  25,  25,  25,  25,  25,  25,  30,  40,  50,  60,  75,  90,  100, 
+        100, 90,  75,  60,  50,  40,  30,  25,  10,  10,  10,  10,  25,  30,  40,  50,  60,  75,  90,  100, 
+        100, 90,  75,  60,  50,  40,  30,  25,  10,  0,   0,   10,  25,  30,  40,  50,  60,  75,  90,  100, 
+        100, 90,  75,  60,  50,  40,  30,  25,  10,  0,   0,   10,  25,  30,  40,  50,  60,  75,  90,  100, 
+        100, 90,  75,  60,  50,  40,  30,  25,  10,  10,  10,  10,  25,  30,  40,  50,  60,  75,  90,  100, 
+        100, 90,  75,  60,  50,  40,  30,  25,  25,  25,  25,  25,  25,  30,  40,  50,  60,  75,  90,  100, 
+        100, 90,  75,  60,  50,  40,  30,  30,  30,  30,  30,  30,  30,  30,  40,  50,  60,  75,  90,  100, 
+        100, 90,  75,  60,  50,  40,  40,  40,  40,  40,  40,  40,  40,  40,  40,  50,  60,  75,  90,  100, 
+        100, 90,  75,  60,  50,  50,  50,  50,  50,  50,  50,  50,  50,  50,  50,  50,  60,  75,  90,  100, 
+        100, 90,  75,  60,  60,  60,  60,  60,  60,  60,  60,  60,  60,  60,  60,  60,  60,  75,  90,  100, 
+        100, 90,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  75,  90,  100, 
+        100, 90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  90,  100, 
+        100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,
     ]
 
-    TURTLE_WEIGHTS: list[float] = [
+    TURTLE_WEIGHTS: list[int] = [
         512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 
         256, 256, 128, 64, 32, 16, 8, 4, 2, 1, 1, 2, 4, 8, 16, 32, 64, 128, 256, 256, 
         128, 128, 128, 64, 32, 16, 8, 4, 2, 1, 1, 2, 4, 8, 16, 32, 64, 128, 128, 128, 
@@ -214,7 +214,7 @@ class TileWeightEngine(Engine):
         'turtle': TURTLE_WEIGHTS
     }
 
-    def __init__(self, name: str="TileWeight", weight_map: str='wall_crawl', custom_weights: list[float]=None): 
+    def __init__(self, name: str="TileWeight", weight_map: str='wall_crawl', custom_weights: list[int | float]=None): 
         """
         Current `weight_map` built-in options are 'wall_crawl' and 'turtle'
         Can optionally provide a custom set of weights instead
@@ -224,7 +224,7 @@ class TileWeightEngine(Engine):
 
         if custom_weights is not None:
             if len(custom_weights) != 20 * 20:
-                raise Exception("TileWeightEngine custom_weights must be a list of exactly 400 floats")
+                raise Exception("TileWeightEngine custom_weights must be a list of exactly 400 values")
             self.weights = custom_weights
         
         else:
@@ -236,16 +236,15 @@ class TileWeightEngine(Engine):
 
         cur_player = board.current_player
 
-        def get_owned_tiles_list(board: tilewe.Board, player: tilewe.Color):
-            ownership = []
-            for tile in tilewe.TILES:
-                ownership.append(1 if board.color_at(tile) == player else 0)
-            return ownership   
+        def evaluate_move_weight(move: tilewe.Move) -> float: 
+            total: float = 0.0
 
-        def tile_score_after_move(move: tilewe.Move) -> int: 
-            with MoveExecutor(board, move):
-                owned_tiles = get_owned_tiles_list(board, cur_player)
-                return sum([t[0] * t[1] for t in zip(owned_tiles, self.weights)])
+            to_coords = tilewe.tile_to_coords(move.to_tile) 
+            for coords in tilewe.piece_tile_coords(move.piece, move.rotation, move.contact): 
+                coords = (coords[0] + to_coords[0], coords[1] + to_coords[1])
+                total += self.weights[coords[1] * 20 + coords[0]]
+
+            return total
 
         moves = board.generate_legal_moves(unique=True)
         random.shuffle(moves)
@@ -255,4 +254,4 @@ class TileWeightEngine(Engine):
             corner = board.player_corners(cur_player)[0]
             moves = [i for i in moves if i.to_tile == corner]
 
-        return max(moves, key=tile_score_after_move)
+        return max(moves, key=evaluate_move_weight)


### PR DESCRIPTION
Wall crawler had one row that was incorrectly duplicated: 
`1, 0.9, 0.75, 0.6, 0.5, 0.4, 0.3, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.3, 0.4, 0.5, 0.6, 0.75, 0.9, 1,`
whereas the middle row should have been duplicated instead: 
`1, 0.9, 0.75, 0.6, 0.5, 0.4, 0.3, 0.25, 0.1, 0, 0, 0.1, 0.25, 0.3, 0.4, 0.5, 0.6, 0.75, 0.9, 1,`

Afterwards, I converted the array to integers get rid of floating point inconsistencies for testing the next step: 

`TileWeightEngine` does not need to play moves to evaluate them. The only thing it cares about is how much the sum of move's tiles add up to in its weight table, and the rest of the game state doesn't matter. By looping through the move's tiles instead of making the move, evaluating the entire board, and unmaking the move, we get a speed-up of around 200x on my machine. 

Previous approach: 
```
Game  1: WallCrawler    WallCrawler    Turtle         Turtle           Scores: [78, 69, 78, 74]  Winner(s): WallCrawler, Turtle
Game  2: WallCrawler    Turtle         Turtle         WallCrawler      Scores: [74, 70, 64, 77]  Winner(s): WallCrawler
Game  3: WallCrawler    WallCrawler    Turtle         Turtle           Scores: [78, 69, 78, 74]  Winner(s): WallCrawler, Turtle
Game  4: Turtle         WallCrawler    Turtle         WallCrawler      Scores: [75, 77, 79, 73]  Winner(s): Turtle
Game  5: WallCrawler    WallCrawler    Turtle         Turtle           Scores: [78, 69, 78, 74]  Winner(s): WallCrawler, Turtle
Game  6: Turtle         Turtle         WallCrawler    WallCrawler      Scores: [76, 77, 74, 77]  Winner(s): Turtle, WallCrawler
Game  7: WallCrawler    WallCrawler    Turtle         Turtle           Scores: [78, 69, 78, 74]  Winner(s): WallCrawler, Turtle
Game  8: Turtle         Turtle         WallCrawler    WallCrawler      Scores: [76, 77, 74, 77]  Winner(s): Turtle, WallCrawler
Game  9: Turtle         WallCrawler    WallCrawler    Turtle           Scores: [73, 76, 73, 68]  Winner(s): WallCrawler
Game 10: WallCrawler    Turtle         Turtle         WallCrawler      Scores: [74, 70, 64, 77]  Winner(s): WallCrawler

Ranking by elo_end desc:
Rank Name                       Elo  Games      Score  Avg Score   Wins  Win Rate
   0 WallCrawler                 15     10        751      75.10      5    50.00%
   1 WallCrawler                  5     10        740      74.00      4    40.00%
   2 Turtle                      -3     10        740      74.00      4    40.00%
   3 Turtle                     -17     10        737      73.70      3    30.00%

Tournament ran for 201.5269s with avg match duration 20.1505s
```

New approach: 
```
Game  1: WallCrawler    WallCrawler    Turtle         Turtle           Scores: [78, 69, 78, 74]  Winner(s): WallCrawler, Turtle
Game  2: WallCrawler    Turtle         Turtle         WallCrawler      Scores: [74, 70, 64, 77]  Winner(s): WallCrawler
Game  3: WallCrawler    WallCrawler    Turtle         Turtle           Scores: [78, 69, 78, 74]  Winner(s): WallCrawler, Turtle
Game  4: Turtle         WallCrawler    Turtle         WallCrawler      Scores: [75, 77, 79, 73]  Winner(s): Turtle
Game  5: WallCrawler    WallCrawler    Turtle         Turtle           Scores: [78, 69, 78, 74]  Winner(s): WallCrawler, Turtle
Game  6: Turtle         Turtle         WallCrawler    WallCrawler      Scores: [76, 77, 74, 77]  Winner(s): Turtle, WallCrawler
Game  7: WallCrawler    WallCrawler    Turtle         Turtle           Scores: [78, 69, 78, 74]  Winner(s): WallCrawler, Turtle
Game  8: Turtle         Turtle         WallCrawler    WallCrawler      Scores: [76, 77, 74, 77]  Winner(s): Turtle, WallCrawler
Game  9: Turtle         WallCrawler    WallCrawler    Turtle           Scores: [73, 76, 73, 68]  Winner(s): WallCrawler
Game 10: WallCrawler    Turtle         Turtle         WallCrawler      Scores: [74, 70, 64, 77]  Winner(s): WallCrawler

Ranking by elo_end desc:
Rank Name                       Elo  Games      Score  Avg Score   Wins  Win Rate
   0 WallCrawler                 15     10        751      75.10      5    50.00%
   1 WallCrawler                  5     10        740      74.00      4    40.00%
   2 Turtle                      -3     10        740      74.00      4    40.00%
   3 Turtle                     -17     10        737      73.70      3    30.00%

Tournament ran for 0.9931s with avg match duration 0.0951s
```