### PR TITLE
`add_corner` and `out_of_bounds` improvements

### DIFF
--- a/tilewe/__init__.py
+++ b/tilewe/__init__.py
@@ -438,12 +438,8 @@ def tile_to_index(tile: Tile) -> int:
     # y * width + x
     return tile[0] * 20 + tile[1]
 
-def out_of_bounds(tile: Tile) -> bool: 
-    if tile[0] < 0 or tile[0] >= 20: 
-        return True 
-    if tile[1] < 0 or tile[1] >= 20: 
-        return True 
-    return False
+def out_of_bounds(tile: Tile) -> bool:
+    return not (0 <= tile[0] < 20 and 0 <= tile[1] < 20)
 
 # helpers for retrieving information about game pieces
 def n_piece_contacts(piece: Piece) -> int: 
@@ -613,12 +609,10 @@ class _Player:
             pt = (rel[0] + tile[0], rel[1] + tile[1])
             if out_of_bounds(pt) or self.board._tiles[pt] != 0:
                 bad |= _PRP_WITH_REL_COORD[rel]
-            if not out_of_bounds(pt) and self.board._tiles[pt] == self.id + 1:
+            elif self.board._tiles[pt] == self.id + 1:
                 bad |= _PRP_WITH_ADJ_REL_COORD[rel]
 
-        prps = self._prps & ~bad
-        if prps > 0:
-            self.corners[tile] = prps
+        self.corners[tile] = self._prps & ~bad
 
 class Move:
     """

--- a/tilewe/__init__.py
+++ b/tilewe/__init__.py
@@ -607,9 +607,10 @@ class _Player:
 
         for rel in _PRP_REL_COORDS: 
             pt = (rel[0] + tile[0], rel[1] + tile[1])
-            if out_of_bounds(pt) or self.board._tiles[pt] != 0:
+            oob = out_of_bounds(pt)
+            if oob or self.board._tiles[pt] != 0:
                 bad |= _PRP_WITH_REL_COORD[rel]
-            elif self.board._tiles[pt] == self.id + 1:
+            if not oob and self.board._tiles[pt] == self.id + 1:
                 bad |= _PRP_WITH_ADJ_REL_COORD[rel]
 
         self.corners[tile] = self._prps & ~bad

--- a/tilewe/__init__.py
+++ b/tilewe/__init__.py
@@ -613,7 +613,9 @@ class _Player:
             if not oob and self.board._tiles[pt] == self.id + 1:
                 bad |= _PRP_WITH_ADJ_REL_COORD[rel]
 
-        self.corners[tile] = self._prps & ~bad
+        prps = self._prps & ~bad
+        if prps > 0:
+            self.corners[tile] = self._prps & ~bad
 
 class Move:
     """


### PR DESCRIPTION
This change to `add_corner` to only call `out_of_bounds` once per `pt` drops `out_of_bounds` from 11.3% of game runtime to 7.0% of game runtime
Additionally (and independently), the change to `out_of_bounds` itself drops it from 11.3% of game runtime to 10.2% of game runtime
Combined the `out_of_bounds` runtime is dropped from 11.3% to ~6% of game runtime 

Additionally one small improvement to `add_corner` removing an unnecessary branch and comparison