### PR TITLE
add `Board_NumPlayerPcs` C function for `board.n_remaining_pieces`

### DIFF
--- a/tilewe/__init__.pyi
+++ b/tilewe/__init__.pyi
@@ -61,3 +61,7 @@ class Board:
     def n_legal_moves(self, for_player: Color=None) -> int: 
         """Gets total number of legal moves for a player"""
         ...
+
+    def n_remaining_pieces(self, for_player: Color=None) -> int: 
+        """Gets total number of pieces remaining for a player"""
+        ...

--- a/tilewe/src/ctilewemodule.c
+++ b/tilewe/src/ctilewemodule.c
@@ -196,6 +196,35 @@ static PyObject* Board_NumLegalMoves(BoardObject* self, PyObject* args, PyObject
     return NULL; 
 }
 
+static PyObject* Board_NumPlayerPcs(BoardObject* self, PyObject* args, PyObject* kwds) 
+{
+    static const char* kwlist[] = 
+    {
+        "for_player", 
+        NULL
+    };
+
+    int player = Tw_Color_None; 
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|i", kwlist, &player)) 
+    {
+        return NULL; 
+    }
+
+    if (player == Tw_Color_None) 
+    {
+        player = self->Board.CurTurn; 
+    }
+
+    if (player >= 0 && player < self->Board.NumPlayers) 
+    {
+        return PyLong_FromLong(Tw_Board_NumPlayerPcs(&self->Board, (Tw_Color) player)); 
+    }
+
+    PyErr_SetString(PyExc_AttributeError, "for_player must be valid or None"); 
+    return NULL; 
+}
+
 static PyObject* Board_Pop(BoardObject* self, PyObject* Py_UNUSED(ignored)) 
 {
     Tw_Board_Pop(&self->Board); 
@@ -249,6 +278,7 @@ static PyMethodDef Board_methods[] =
     { "pop", Board_Pop, METH_NOARGS, "Undoes a move" }, 
     { "color_at", Board_ColorAt, METH_VARARGS | METH_KEYWORDS, "Color that claimed the tile" }, 
     { "n_legal_moves", Board_NumLegalMoves, METH_VARARGS | METH_KEYWORDS, "Gets total number of legal moves for a player" }, 
+    { "n_remaining_pieces", Board_NumPlayerPcs, METH_VARARGS | METH_KEYWORDS, "Gets total number of pieces remaining for a player" }, 
     // { "copy", Board_Copy, METH_NOARGS, "Returns a clone of the current board state" }, 
     { NULL }
 };


### PR DESCRIPTION
Just wanted to make sure I could follow through on the whole C/Python implementation sides! 

This PR implements the `board.n_remaining_pieces` with a Python C API function `Board_NumPlayerPcs` which uses `Tw_Board_NumPlayerPcs`.