### PR TITLE
implement `player_corners` in the `C` API, `C` API fixes, and update `C` submodule

### DIFF
--- a/tilewe/__init__.pyi
+++ b/tilewe/__init__.pyi
@@ -69,4 +69,8 @@ class Board:
     def n_player_corners(self, for_player: Color=None) -> int: 
         """Gets total number of open corners for a player"""
         ...
+
+    def player_corners(self, for_player: Color=None) -> list[tilewe.Tile]: 
+        """Gets a list of the open corners for a player"""
+        ...
         

--- a/tilewe/__init__.pyi
+++ b/tilewe/__init__.pyi
@@ -65,3 +65,8 @@ class Board:
     def n_remaining_pieces(self, for_player: Color=None) -> int: 
         """Gets total number of pieces remaining for a player"""
         ...
+
+    def n_player_corners(self, for_player: Color=None) -> int: 
+        """Gets total number of open corners for a player"""
+        ...
+        

--- a/tilewe/engine.py
+++ b/tilewe/engine.py
@@ -139,11 +139,12 @@ class MaximizeMoveDifferenceEngine(Engine):
         random.shuffle(moves) 
         
         player = board.current_player
+        N = board.n_players
 
         def eval_after_move(m: tilewe.Move) -> int: 
             with MoveExecutor(board, m):
                 total = 0
-                for color in range(board.n_players): 
+                for color in range(N): 
                     n_moves = board.n_legal_moves(for_player=color)
                     total += n_moves * (1 if color == player else -1)
                 return total

--- a/tilewe/src/ctilewemodule.c
+++ b/tilewe/src/ctilewemodule.c
@@ -225,6 +225,40 @@ static PyObject* Board_NumPlayerPcs(BoardObject* self, PyObject* args, PyObject*
     return NULL; 
 }
 
+static PyObject* Board_NumPlayerOpenCorners(BoardObject* self, PyObject* args, PyObject* kwds) 
+{
+    static const char* kwlist[] = 
+    {
+        "for_player", 
+        NULL
+    };
+
+    int player = Tw_Color_None; 
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|i", kwlist, &player)) 
+    {
+        return NULL; 
+    }
+
+    if (player == Tw_Color_None) 
+    {
+        player = self->Board.CurTurn; 
+    }
+
+    if (player >= 0 && player < self->Board.NumPlayers) 
+    {
+        long openCorners = 0;
+        Tw_TileSet_FOR_EACH(self->Board.Players[player].OpenCorners.Keys, tile, 
+        {
+            openCorners++;
+        });
+        return PyLong_FromLong(openCorners); 
+    }
+
+    PyErr_SetString(PyExc_AttributeError, "for_player must be valid or None"); 
+    return NULL; 
+}
+
 static PyObject* Board_Pop(BoardObject* self, PyObject* Py_UNUSED(ignored)) 
 {
     Tw_Board_Pop(&self->Board); 
@@ -279,6 +313,7 @@ static PyMethodDef Board_methods[] =
     { "color_at", Board_ColorAt, METH_VARARGS | METH_KEYWORDS, "Color that claimed the tile" }, 
     { "n_legal_moves", Board_NumLegalMoves, METH_VARARGS | METH_KEYWORDS, "Gets total number of legal moves for a player" }, 
     { "n_remaining_pieces", Board_NumPlayerPcs, METH_VARARGS | METH_KEYWORDS, "Gets total number of pieces remaining for a player" }, 
+    { "n_player_corners", Board_NumPlayerOpenCorners, METH_VARARGS | METH_KEYWORDS, "Gets total number of open corners for a player" }, 
     // { "copy", Board_Copy, METH_NOARGS, "Returns a clone of the current board state" }, 
     { NULL }
 };

--- a/tilewe/src/ctilewemodule.c
+++ b/tilewe/src/ctilewemodule.c
@@ -220,7 +220,7 @@ static PyObject* Board_NumPlayerPcs(BoardObject* self, PyObject* args, PyObject*
     return PyLong_FromLong(Tw_Board_NumPlayerPcs(&self->Board, (Tw_Color) player)); 
 }
 
-static PyObject* Board_PlayerOpenCorners(BoardObject* self, PyObject* args, PyObject* kwds) 
+static PyObject* Board_PlayerCorners(BoardObject* self, PyObject* args, PyObject* kwds) 
 {
     int player;
     if (!ForPlayerArgHandler(self, args, kwds, &player))
@@ -228,30 +228,25 @@ static PyObject* Board_PlayerOpenCorners(BoardObject* self, PyObject* args, PyOb
         return NULL;
     }
 
-    // count the open corners
-    Py_ssize_t openCorners = 0;
-    Tw_TileSet_FOR_EACH(self->Board.Players[player].OpenCorners.Keys, tile, 
-    {
-        openCorners++;
-    });
+    // get a list of the player's open corners
+    Tw_TileList openCorners;
+    Tw_InitTileList(&openCorners);
+    Tw_Board_PlayerCorners(&self->Board, player, &openCorners);
 
     // build Python list of the open corner tiles
-    PyObject* list = PyList_New(openCorners); 
-    Py_ssize_t cornerIndex = 0;
-    Tw_TileSet_FOR_EACH(self->Board.Players[player].OpenCorners.Keys, tile, 
-    {
+    PyObject* list = PyList_New(openCorners.Count); 
+    for (int i = 0; i < openCorners.Count; i++) {
         PyList_SetItem(
             list, 
-            cornerIndex, 
-            PyLong_FromUnsignedLong((unsigned long) tile)
+            i, 
+            PyLong_FromUnsignedLong((unsigned long) openCorners.Elements[i])
         ); 
-        cornerIndex++;
-    });
+    }
 
     return list; 
 }
 
-static PyObject* Board_NumPlayerOpenCorners(BoardObject* self, PyObject* args, PyObject* kwds) 
+static PyObject* Board_NumPlayerCorners(BoardObject* self, PyObject* args, PyObject* kwds) 
 {
     int player;
     if (!ForPlayerArgHandler(self, args, kwds, &player))
@@ -259,13 +254,7 @@ static PyObject* Board_NumPlayerOpenCorners(BoardObject* self, PyObject* args, P
         return NULL;
     }
 
-    long openCorners = 0;
-    Tw_TileSet_FOR_EACH(self->Board.Players[player].OpenCorners.Keys, tile, 
-    {
-        openCorners++;
-    });
-
-    return PyLong_FromLong(openCorners); 
+    return PyLong_FromLong(Tw_Board_NumPlayerCorners(&self->Board, player)); 
 }
 
 static PyObject* Board_Pop(BoardObject* self, PyObject* Py_UNUSED(ignored)) 
@@ -322,8 +311,8 @@ static PyMethodDef Board_methods[] =
     { "color_at", Board_ColorAt, METH_VARARGS | METH_KEYWORDS, "Color that claimed the tile" }, 
     { "n_legal_moves", Board_NumLegalMoves, METH_VARARGS | METH_KEYWORDS, "Gets total number of legal moves for a player" }, 
     { "n_remaining_pieces", Board_NumPlayerPcs, METH_VARARGS | METH_KEYWORDS, "Gets total number of pieces remaining for a player" }, 
-    { "n_player_corners", Board_NumPlayerOpenCorners, METH_VARARGS | METH_KEYWORDS, "Gets total number of open corners for a player" }, 
-    { "player_corners", Board_PlayerOpenCorners, METH_VARARGS | METH_KEYWORDS, "Gets a list of the open corners for a player" }, 
+    { "n_player_corners", Board_NumPlayerCorners, METH_VARARGS | METH_KEYWORDS, "Gets total number of open corners for a player" }, 
+    { "player_corners", Board_PlayerCorners, METH_VARARGS | METH_KEYWORDS, "Gets a list of the open corners for a player" }, 
     // { "copy", Board_Copy, METH_NOARGS, "Returns a clone of the current board state" }, 
     { NULL }
 };

--- a/tilewe/tournament.py
+++ b/tilewe/tournament.py
@@ -418,14 +418,14 @@ class Tournament:
         try: 
             engine_to_player = { value: key for key, value in enumerate(player_to_engine) }
             while not board.finished: 
-                engine = self.engines[player_to_engine[board.current_player]]
 
                 # ghetto board copy to avoid exposing the real board to the engine
-                b = tilewe.Board(n_players=len(player_to_engine))
+                board_copy = tilewe.Board(n_players=len(player_to_engine))
                 for move in board.moves: 
-                    b.push(move) 
+                    board_copy.push(move) 
+                engine = self.engines[player_to_engine[board_copy.current_player]]
 
-                move = engine.search(b, self.move_seconds) 
+                move = engine.search(board_copy, self.move_seconds) 
                 # move = engine.search(board.copy_current_state(), self.move_seconds) 
                 # TODO test legality 
                 board.push(move) 


### PR DESCRIPTION
- Implements `n_player_corners` in `tilewe.Board` with C API function `Board_NumPlayerOpenCorners`
- Implements `player_corners` in `tilewe.Board` with C API function `Board_PlayerOpenCorners`
- Refactors C API functions that have only a `for_player` arg to all use the `ForPlayerArgHandler` helper
- Fixes an error in C API function `Board_CurrentPlayer` where it was returning the `current_player` as a `bool` instead of `int` (`long`)
- Updates the `C` `tilewe` submodule to export `Tile.h` in `Tilewe.h` and refactor `FOR_EACH` macros

Note: relies on a local commit [1b6c595e389bebe3c54886578888551e52fbcbcf ](https://github.com/nhamil/tilewe/tree/1b6c595e389bebe3c54886578888551e52fbcbcf) being pushed to https://github.com/nhamil/tilewe later, once access is available. (edit: done)